### PR TITLE
verifying if paths exist before format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import glob from "glob";
 
 import { formatFileStructure } from "./index/formatFileStructure";
 import { version } from "../package.json";
+import { existsSync } from "fs-extra";
 
 const { argv, env } = process;
 const defaults = {
@@ -69,6 +70,12 @@ const run = (args: any[]) => {
   paths.forEach(path => {
     const filesToStructure = glob.sync(path);
     const filesToFixImports = filesToStructure;
+
+    if (!existsSync(path)) {
+      console.log("Unable to resolve the path:", path);
+      return;
+    }
+
     console.log("Files to structure:");
     console.log(filesToStructure);
     formatFileStructure(filesToStructure, filesToFixImports);


### PR DESCRIPTION
Giving a non resolvable path to Destiny returned an error from Node. I've made a condition to check if the path exist.

Before:
```
➜  destiny git:(fix/not-existing-path) ✗ node dist/src/index.js dsdsd
Files to structure:
[]
(node:8165) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at Object.exports.findSharedParent (/home/anatole/dev/destiny/dist/src/index/formatFileStructure/shared/findSharedParent.js:13:34)
    at Object.buildGraph (/home/anatole/dev/destiny/dist/src/index/formatFileStructure/buildGraph.js:12:45)
    at /home/anatole/dev/destiny/dist/src/index/formatFileStructure.js:20:74
    at Generator.next (<anonymous>)
    at /home/anatole/dev/destiny/dist/src/index/formatFileStructure.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/anatole/dev/destiny/dist/src/index/formatFileStructure.js:4:12)
    at Object.exports.formatFileStructure (/home/anatole/dev/destiny/dist/src/index/formatFileStructure.js:19:69)
    at paths.forEach.path (/home/anatole/dev/destiny/dist/src/index.js:68:31)
    at Array.forEach (<anonymous>)
(node:8165) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handle
```

After:
```
➜  destiny git:(fix/not-existing-path) node dist/src/index.js dsdsd
Unable to resolve the path: dsdsd
```