### PR TITLE
fixing npm watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "run-s clean build:*",
+    "build": "npm-run-all clean -p 'build:* {*}' --",
     "build:cjs": "babel src --extensions '.ts' --out-dir dist",
     "format": "run-s format:*",
     "format:eslint": "npm run lint -- --fix",
@@ -20,7 +20,7 @@
     "start": "nodemon dist/index.js",
     "test": "jest tests",
     "tr": "jest",
-    "watch": "npm run build -- --watch"
+    "watch": "npm-run-all -p 'build {*}' -- --watch"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
The `--watch` flag wasn't passed to the `build:cjs` script. This resulted in an error.
It should be fixed with this PR.