### PR TITLE
.editorconfig and prepare script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format:eslint": "npm run lint -- --fix",
     "format:prettier": "prettier --write '{**/*,*}.{js,json,md,ts,yaml}'",
     "lint": "eslint '{src,test}/**/*.{js,ts}'",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "start": "nodemon lib/destiny.js",
     "test": "jest",


### PR DESCRIPTION
- `prepare` script allows the package to be installed directly from github.
- `.editorconfig` standard editor configuration used by most editors https://editorconfig.org/.