### PR TITLE
fix: new imports not working if they are similar

### DIFF
--- a/src/index/formatFileStructure/fixImports.ts
+++ b/src/index/formatFileStructure/fixImports.ts
@@ -55,7 +55,9 @@ export const fixImports = (files: string[], rootOptions: RootOption[]) => {
       const newImportText = getNewImportPath(absPath, newFilePath, rootOptions);
 
       if (newImportText) {
-        newText = newText.replace(imp[1], newImportText);
+        newText = newText
+          .replace(`'${imp[1]}'`, `'${newImportText}'`)
+          .replace(`"${imp[1]}"`, `"${newImportText}"`);
       }
     }
     if (newText !== ogText) {


### PR DESCRIPTION
I had some troubles in one of my projects when the paths were too similar eg:

```js
import "../components"
import "../../components"
```

The regexp for `../components` would also match for `../../components` and it would produce an incorrect file tree. 
