### PR TITLE
fix/separate-getfilepaths-into-module

### DIFF
--- a/src/getFilePaths.ts
+++ b/src/getFilePaths.ts
@@ -1,0 +1,62 @@
+import glob from "glob";
+import path from "path";
+import { existsSync, lstatSync, readdirSync } from "fs-extra";
+
+import logger from "./shared/logger";
+
+const isDirectory = (filePath: string) => lstatSync(filePath).isDirectory();
+const isFile = (filePath: string) => lstatSync(filePath).isFile();
+
+const globSearch = (pattern: string) => {
+  const matches = glob.sync(pattern);
+  const files = matches.filter(match => isFile(match));
+
+  if (files.length === 0) {
+    logger.error("Could not find any files for: " + pattern, 1);
+  }
+
+  return files;
+};
+
+/** Recursively get all file paths. */
+export const getFilePaths = (
+  paths: string[],
+  options = { detectRoots: false }
+) => {
+  const files: string[][] = [];
+
+  while (paths.length > 0) {
+    const filePath = paths.pop();
+
+    if (filePath == null || filePath.length === 0) continue;
+
+    const isGlobPattern = glob.hasMagic(filePath);
+    if (isGlobPattern) {
+      files.push(globSearch(filePath));
+      continue;
+    }
+
+    if (existsSync(filePath)) {
+      if (isFile(filePath)) {
+        files.push([filePath]);
+      } else if (isDirectory(filePath)) {
+        if (options.detectRoots) {
+          paths.push(
+            ...readdirSync(path.resolve(filePath)).map(x =>
+              path.join(filePath, x)
+            )
+          );
+          options.detectRoots = false;
+        } else {
+          paths.push(path.join(filePath, "/**/*.*"));
+        }
+      }
+    } else {
+      logger.error(`Unable to resolve the path: ${filePath}`);
+    }
+  }
+
+  return files;
+};
+
+export default getFilePaths;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import glob from "glob";
-import { existsSync, lstatSync, readdirSync } from "fs-extra";
 import path from "path";
 
+import getFilePaths from "./getFilePaths";
+import logger from "./shared/logger";
 import { formatFileStructure } from "./index/formatFileStructure";
 import { version } from "../package.json";
-import logger from "./shared/logger";
 
 const { argv } = process;
 const defaults = {
@@ -66,56 +65,6 @@ const parseArgs = (args: any[]): ParsedArgs =>
     return acc;
   }, defaults);
 
-const getFilePaths = (paths: string[], detectRoots: boolean) => {
-  const files: string[][] = [];
-
-  while (paths.length > 0) {
-    const filePath = paths.pop();
-
-    if (!filePath) continue;
-    if (glob.hasMagic(filePath)) {
-      const globFiles = glob.sync(filePath);
-
-      if (globFiles.length === 0) {
-        logger.error("Could not find any files for: " + filePath, 1);
-      }
-      files.push(
-        globFiles.filter(x => {
-          const isFile = lstatSync(x).isFile();
-
-          if (!isFile) {
-            logger.warn(`Skipping non file: ${x}`);
-          }
-          return isFile;
-        })
-      );
-    } else if (!existsSync(filePath)) {
-      logger.error(`Unable to resolve the path: ${filePath}`);
-    } else {
-      const stats = lstatSync(filePath);
-
-      if (stats.isDirectory()) {
-        if (detectRoots) {
-          paths.push(
-            ...readdirSync(path.resolve(filePath)).map(x =>
-              path.join(filePath, x)
-            )
-          );
-          detectRoots = false;
-        } else {
-          paths.push(path.join(filePath, "/**/*.*"));
-        }
-      } else if (stats.isFile()) {
-        files.push([filePath]);
-      } else {
-        logger.warn(`Skipping: ${filePath}`);
-      }
-    }
-  }
-
-  return files;
-};
-
 export const run = async (args: any[]) => {
   const { options, paths } = parseArgs(args);
 
@@ -125,7 +74,7 @@ export const run = async (args: any[]) => {
 
   logger.info("Resolving files.");
 
-  const filesToRestructure = getFilePaths(paths, options.detectRoots);
+  const filesToRestructure = getFilePaths(paths, options);
   const filesToEdit = filesToRestructure.flat();
 
   if (filesToRestructure.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import path from "path";
 
-import getFilePaths from "./getFilePaths";
+import getFilePaths from "./index/getFilePaths";
 import logger from "./shared/logger";
 import { formatFileStructure } from "./index/formatFileStructure";
 import { version } from "../package.json";

--- a/src/index/getFilePaths.ts
+++ b/src/index/getFilePaths.ts
@@ -2,7 +2,7 @@ import glob from "glob";
 import path from "path";
 import { existsSync, lstatSync, readdirSync } from "fs-extra";
 
-import logger from "./shared/logger";
+import logger from "../shared/logger";
 
 const isDirectory = (filePath: string) => lstatSync(filePath).isDirectory();
 const isFile = (filePath: string) => lstatSync(filePath).isFile();

--- a/src/index/getFilePaths.ts
+++ b/src/index/getFilePaths.ts
@@ -41,11 +41,11 @@ export const getFilePaths = (
         files.push([filePath]);
       } else if (isDirectory(filePath)) {
         if (options.detectRoots) {
-          paths.push(
-            ...readdirSync(path.resolve(filePath)).map(x =>
-              path.join(filePath, x)
-            )
-          );
+          const childDirectories = readdirSync(path.resolve(filePath))
+            .map(x => path.join(filePath, x))
+            .filter(x => isDirectory(x));
+
+          paths.push(...childDirectories);
           options.detectRoots = false;
         } else {
           paths.push(path.join(filePath, "/**/*.*"));


### PR DESCRIPTION
Separate `getFilePaths` into its own module and refactor / simplify its logic.

It also repairs the `--detectRoots` option so it only restructures the child directories of the path given. I assume that this is the way you intended it to work @benawad?

I think we may need to change name from `detectRoots` to something else because it is not clear what the option is intended to do.