### PR TITLE
feat: add support for sass

### DIFF
--- a/src/index/formatFileStructure/buildGraph.ts
+++ b/src/index/formatFileStructure/buildGraph.ts
@@ -50,6 +50,6 @@ export function buildGraph(files: string[]) {
     graph,
     files: totalFiles,
     oldGraph,
-    useForwardSlash: numForwardSlashes >= numBackSlashes ? true : false,
+    useForwardSlash: numForwardSlashes >= numBackSlashes,
   };
 }

--- a/src/index/formatFileStructure/shared/customResolve.ts
+++ b/src/index/formatFileStructure/shared/customResolve.ts
@@ -4,6 +4,6 @@ import resolve from "resolve";
 export const customResolve = (id: string, basedir: string) => {
   return resolve.sync(id, {
     basedir,
-    extensions: [".js", ".jsx", ".ts", ".tsx", ".svg"], // .svg is for create-react-app
+    extensions: [".js", ".jsx", ".sass", ".scss", ".svg", ".ts", ".tsx"],
   });
 };


### PR DESCRIPTION
This commit fixes https://github.com/benawad/destiny/issues/63. If you run it on https://github.com/AnatoleLucet/destiny-scss-error the result is a bit strange due to it creating nested index folders. We'll need to figure out a good way to handle this.

Output on above `destiny-scss-error` repo:
```
src
├── index
│  ├── App
│  │  ├── App.css
│  │  └── logo.svg
│  ├── App.js
│  ├── App.test.js
│  ├── index
│  │  └── foo.sass
│  ├── index.sass
│  └── serviceWorker.js
├── index.js
└── setupTests.js
```