### PR TITLE
fix/ensure unique edges

### DIFF
--- a/src/index/generateTrees/buildGraph.ts
+++ b/src/index/generateTrees/buildGraph.ts
@@ -1,4 +1,5 @@
 import path from "path";
+
 import { findEdges } from "../shared/findEdges";
 import { Graph, OldGraph } from "./shared/Graph";
 import { findSharedParent } from "./shared/findSharedParent";
@@ -13,6 +14,7 @@ export function buildGraph(files: string[]) {
   const totalFiles: string[] = [];
   let numForwardSlashes = 0;
   let numBackSlashes = 0;
+
   for (let file of files) {
     if (file === ".git") {
       continue;

--- a/src/index/generateTrees/buildGraph/addEdge.ts
+++ b/src/index/generateTrees/buildGraph/addEdge.ts
@@ -4,5 +4,6 @@ export function addEdgeToGraph([start, end]: [string, string], graph: Graph) {
   if (!(start in graph)) {
     graph[start] = [];
   }
+  if (graph[start].includes(end)) return;
   graph[start].push(end);
 }

--- a/tests/__snapshots__/end-to-end.test.ts.snap
+++ b/tests/__snapshots__/end-to-end.test.ts.snap
@@ -337,6 +337,33 @@ import \\"@testing-library/jest-dom/extend-expect\\";
 "
 `;
 
+exports[`end-to-end duplicate-imports 1`] = `
+"duplicate-imports
+├── index
+│   ├── routes
+│   │   └── home.js
+│   └── routes.js
+└── index.js"
+`;
+
+exports[`end-to-end duplicate-imports: duplicate-imports/index.js 1`] = `
+"/* eslint-disable*/
+
+import { five } from \\"./index/routes\\";
+import { five } from \\"./index/routes\\";
+"
+`;
+
+exports[`end-to-end duplicate-imports: duplicate-imports/index/routes.js 1`] = `
+"export * from \\"./routes/home\\";
+"
+`;
+
+exports[`end-to-end duplicate-imports: duplicate-imports/index/routes/home.js 1`] = `
+"export const five = 5;
+"
+`;
+
 exports[`end-to-end duplicates 1`] = `
 "duplicates
 ├── index

--- a/tests/fixtures/duplicate-imports/home.js
+++ b/tests/fixtures/duplicate-imports/home.js
@@ -1,0 +1,1 @@
+export const five = 5;

--- a/tests/fixtures/duplicate-imports/index.js
+++ b/tests/fixtures/duplicate-imports/index.js
@@ -1,0 +1,4 @@
+/* eslint-disable*/
+
+import { five } from "./routes";
+import { five } from "./routes";

--- a/tests/fixtures/duplicate-imports/routes.js
+++ b/tests/fixtures/duplicate-imports/routes.js
@@ -1,0 +1,1 @@
+export * from "./home";


### PR DESCRIPTION
Only add a edge if it is unique. This allows for a lower run time but
also makes our graph design easier to understand and predict. It makes
no difference for us in functionality as we only care about what modules
we import and not what we import from those modules.

This solves #73.