### PR TITLE
fix: Fix time complexity when searching for common parent dir

### DIFF
--- a/src/index/generateTrees/shared/findSharedParent.ts
+++ b/src/index/generateTrees/shared/findSharedParent.ts
@@ -2,22 +2,20 @@ import path from "path";
 
 /** Find the common parent directory between all paths. */
 export const findSharedParent = (paths: string[]) => {
-  const [firstPath] = paths;
-  if (paths.length === 1) return path.dirname(firstPath);
+  if (paths.length === 1) return path.dirname(paths[0]);
 
-  const [shortest, secondShortest] = paths.sort((a, b) => a.length - b.length);
+  const [shortest, secondShortest] =
+    paths.length > 2 ? paths.sort((a, b) => a.length - b.length) : paths;
 
+  const secondShortestParts = secondShortest.split("/");
   const parentPaths: string[] = [];
-  const [shortestParts, secondShortestParts] = [
-    shortest,
-    secondShortest,
-  ].map(x => x.split("/"));
 
-  shortestParts.forEach((part, idx) => {
-    if (part === secondShortestParts[idx]) {
+  let index = 0;
+  for (const part of shortest.split("/")) {
+    if (part === secondShortestParts[index++]) {
       parentPaths.push(part);
     }
-  });
+  }
 
   return parentPaths.join("/");
 };

--- a/src/index/generateTrees/shared/findSharedParent.ts
+++ b/src/index/generateTrees/shared/findSharedParent.ts
@@ -2,16 +2,19 @@ import path from "path";
 
 /** Find the common parent directory between all paths. */
 export const findSharedParent = (paths: string[]) => {
-  if (paths.length === 1) return path.dirname(paths[0]);
+  const [firstPath] = paths;
+  if (paths.length === 1) return path.dirname(firstPath);
+
+  const [shortest, secondShortest] = paths.sort((a, b) => a.length - b.length);
 
   const parentPaths: string[] = [];
-  const parts: string[][] = paths.map(x => x.split("/"));
-  const firstParts = parts[0];
+  const [shortestParts, secondShortestParts] = [
+    shortest,
+    secondShortest,
+  ].map(x => x.split("/"));
 
-  firstParts.forEach((part, idx) => {
-    const allPartsMatch = parts.every(p => p[idx] === part);
-
-    if (allPartsMatch) {
+  shortestParts.forEach((part, idx) => {
+    if (part === secondShortestParts[idx]) {
       parentPaths.push(part);
     }
   });

--- a/src/index/generateTrees/shared/findSharedParent.ts
+++ b/src/index/generateTrees/shared/findSharedParent.ts
@@ -7,15 +7,10 @@ export const findSharedParent = (paths: string[]) => {
   const [shortest, secondShortest] =
     paths.length > 2 ? paths.sort((a, b) => a.length - b.length) : paths;
 
-  const secondShortestParts = secondShortest.split("/");
-  const parentPaths: string[] = [];
+  const secondShortestParts = secondShortest.split(path.sep);
 
-  let index = 0;
-  for (const part of shortest.split("/")) {
-    if (part === secondShortestParts[index++]) {
-      parentPaths.push(part);
-    }
-  }
-
-  return parentPaths.join("/");
+  return shortest
+    .split(path.sep)
+    .filter((part, idx) => part === secondShortestParts[idx])
+    .join(path.sep);
 };

--- a/tests/find-shared-parent.test.ts
+++ b/tests/find-shared-parent.test.ts
@@ -1,0 +1,21 @@
+import path from "path";
+import glob from "glob";
+import fs from "fs";
+
+import { findSharedParent } from "../src/index/generateTrees/shared/findSharedParent";
+
+const t = (folder: string, g: string) => {
+  it(folder, () => {
+    expect(
+      findSharedParent(
+        glob.sync(path.join(__dirname, "fixtures", folder, "/**/*.js"))
+      )
+    ).toEqual(g);
+  });
+};
+
+describe("findSharedParentTest", () => {
+  for (const dir of fs.readdirSync(path.join(__dirname, "fixtures"))) {
+    t(dir, path.resolve(path.join(__dirname, "fixtures", dir)))
+  }
+});


### PR DESCRIPTION
Small PR to fix the time complexity when searching for a common parent. 

This utility function is used when creating the dependency graph and when creating the fractal tree, so performance gains might be welcome there.

First PR here, so any comments on how to improve are more then welcome!