### PR TITLE
feat: Add CLI flag to rename single files - resolves #18

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  testPathIgnorePatterns: ["/tests/fixtures/", "/test/tmp/"],
+  testPathIgnorePatterns: ["<rootDir>/tests/fixtures/", "<rootDir>/tests/tmp/"],
   coveragePathIgnorePatterns: ["/tests/tmp/"],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,12 @@ import { version } from "../package.json";
 
 const { argv } = process;
 
-type Config = {
-  help: boolean,
-  include: string[],
-  version: boolean,
-  write: boolean,
+export type Config = {
+  help: boolean;
+  include: string[];
+  version: boolean;
+  write: boolean;
+  avoidSingleFile: boolean;
 };
 
 const defaultConfig: Config = {
@@ -23,6 +24,7 @@ const defaultConfig: Config = {
   include: [],
   version: false,
   write: false,
+  avoidSingleFile: false,
 };
 
 const printVersion = () => console.log("v" + version);
@@ -38,9 +40,10 @@ const printHelp = (exitCode: number) => {
 
 {bold OPTIONS}
 
-  -V, --version            output version number
-  -h, --help               output usage information
-  -w, --write              restructure and edit folders and files
+  -V, --version               Output version number
+  -h, --help                  Output usage information
+  -w, --write                 Restructure and edit folders and files
+  -S, --avoid-single-file     Flag to indicate if single files in folders should be avoided
   `
   );
 
@@ -68,6 +71,9 @@ const parseArgs = (args: string[]) => {
       case "--write":
         cliConfig.write = true;
         break;
+      case "-S":
+      case "--avoid-single-file":
+        cliConfig.avoidSingleFile = true;
       case "-G":
       default: {
         if (fs.existsSync(arg) || glob.hasMagic(arg)) {
@@ -107,7 +113,7 @@ export const run = async (args: string[]) => {
     return;
   }
 
-  const rootOptions = generateTrees(restructureMap);
+  const rootOptions = generateTrees(restructureMap, mergedConfig);
 
   if (mergedConfig.write) {
     await formatFileStructure(filesToEdit, rootOptions);

--- a/src/index/generateTrees.ts
+++ b/src/index/generateTrees.ts
@@ -6,8 +6,10 @@ import { RootOption as Root } from "./shared/RootOption";
 import { buildGraph } from "./generateTrees/buildGraph";
 import { findEntryPoints } from "./generateTrees/findEntryPoints";
 import { toFractalTree } from "./generateTrees/toFractalTree";
+import { detectLonelyFiles } from "./shared/detect-lonely-files";
+import { Config } from "../index";
 
-export function generateTrees(restructureMap: { [key: string]: string[] }) {
+export function generateTrees(restructureMap: { [key: string]: string[] }, {avoidSingleFile}: Config) {
   return Object.entries(restructureMap).reduce<Root[]>(
     (rootOptions, [rootPath, filePaths]) => {
       if (filePaths.length <= 1) return rootOptions;
@@ -17,7 +19,12 @@ export function generateTrees(restructureMap: { [key: string]: string[] }) {
       const { graph, files, useForwardSlash, parentFolder } = buildGraph(
         filePaths
       );
-      const tree = toFractalTree(graph, findEntryPoints(graph));
+
+      let tree = toFractalTree(graph, findEntryPoints(graph));
+
+      if (avoidSingleFile) {
+        tree = detectLonelyFiles(tree);
+      }
 
       const usedFilePaths = new Set(Object.entries(graph).flat(2));
       const unusedFiles = files.filter(

--- a/src/index/generateTrees/buildGraph.ts
+++ b/src/index/generateTrees/buildGraph.ts
@@ -16,10 +16,7 @@ const isFilePathIgnored = (filePath: string) => {
 export function buildGraph(filePaths: string[]) {
   const parentFolder = findSharedParent(filePaths);
   const graph: Graph = {};
-  const oldGraph: OldGraph = {};
   const totalFiles: string[] = [];
-  let numForwardSlashes = 0;
-  let numBackSlashes = 0;
 
   for (let filePath of filePaths) {
     if (isFilePathIgnored(filePath)) continue;
@@ -27,21 +24,9 @@ export function buildGraph(filePaths: string[]) {
     filePath = path.resolve(filePath);
 
     const start = path.relative(parentFolder, filePath);
-    if (oldGraph.start == null) {
-      oldGraph[start] = {
-        oldLocation: filePath,
-        imports: [],
-      };
-    }
-
     totalFiles.push(start);
-    findImports(filePath).forEach(importPath => {
-      if (importPath.includes("/")) {
-        numForwardSlashes++;
-      } else if (importPath.includes("\\")) {
-        numBackSlashes++;
-      }
 
+    findImports(filePath).forEach(importPath => {
       const pathWithExtension = customResolve(
         importPath,
         path.dirname(filePath)
@@ -60,19 +45,13 @@ export function buildGraph(filePaths: string[]) {
       if (!graph[start].includes(end)) {
         graph[start].push(end);
       }
-
-      oldGraph[start].imports.push({
-        text: importPath,
-        resolved: end,
-      });
     });
   }
 
   return {
     files: totalFiles,
     graph,
-    oldGraph,
     parentFolder,
-    useForwardSlash: numForwardSlashes >= numBackSlashes,
+    useForwardSlash: path.sep === "/"
   };
 }

--- a/src/index/shared/detect-lonely-files.ts
+++ b/src/index/shared/detect-lonely-files.ts
@@ -1,0 +1,92 @@
+import path from 'path';
+
+const extractParentDirectory = (destination: string): string | undefined => {
+  const parts = destination.split(path.sep);
+
+  if (parts.length === 1) {
+    return;
+  }
+
+  parts.pop();
+
+  return parts.join(path.sep)
+}
+
+const moveUp = (destinationPath: string) => {
+  const parts = destinationPath.split(path.sep);
+
+  return [
+    ...parts.slice(0, parts.length - 2),
+    parts[parts.length - 1]
+  ].join(path.sep)
+}
+
+export const detectLonelyFiles = (tree: Record<string, string>) => {
+  const fractalTree = {...tree};
+  // Reverse lookup destination -> current location
+  const reversedFractalTree: Record<string, string> = {};
+
+  for (const [currentFilePath, destinationFilePath] of Object.entries(fractalTree)) {
+    reversedFractalTree[destinationFilePath] = currentFilePath
+  }
+
+  const dirCounter: Record<string, number> = {}
+
+  // Sort is important here since we want to go from deep in the file structure to top
+  const currentDestinations = Object.values(fractalTree).sort((a, b) => b.length - a.length);
+
+  // Count all occurencies of the parent dirs of the current destinations
+  for (const currentDestination of currentDestinations) {
+    const parentDir = extractParentDirectory(currentDestination);
+
+    if (!parentDir) {
+      continue;
+    }
+
+    if (parentDir in dirCounter) {
+      dirCounter[parentDir] = dirCounter[parentDir] + 1;
+      continue;
+    }
+
+    dirCounter[parentDir] = 1
+  }
+
+  /**
+   * Loop over all the destinations again and move them up if they are lonely files
+   */
+  for (const currentDestination of currentDestinations) {
+    const startParentDir = extractParentDirectory(currentDestination);
+
+    if (!startParentDir) {
+      continue;
+    }
+
+    let counter = dirCounter[startParentDir];
+    let newDestination = currentDestination;
+    let parentDir: string | undefined = startParentDir;
+
+    while (counter === 1) {
+      parentDir = extractParentDirectory(newDestination);
+
+      if (!parentDir) {
+        break;
+      }
+
+      if (startParentDir === parentDir) {
+        counter = 1
+      } else if (parentDir in dirCounter) {
+        counter = dirCounter[parentDir] + 1
+      }
+
+      dirCounter[parentDir] = counter;
+
+      if (counter === 1) {
+        newDestination = moveUp(newDestination);
+      }
+    }
+
+    fractalTree[reversedFractalTree[currentDestination]] = newDestination;
+  }
+
+  return fractalTree;
+}

--- a/tests/__snapshots__/end-to-end.test.ts.snap
+++ b/tests/__snapshots__/end-to-end.test.ts.snap
@@ -1,5 +1,600 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`end-to-end --avoid-single-file commented-imports 1`] = `
+"commented-imports
+├── existent.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file commented-imports: commented-imports/existent.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file commented-imports: commented-imports/index.js 1`] = `
+"require(\\"./existent\\");
+// require(\\"./non-existent\\");
+// import non from \\"./non-existent\\";
+// export * from \\"./non-existent\\";
+
+/*
+require(\\"./non-existent\\");
+import non from \\"./non-existent\\";
+export * from \\"./non-existent\\";
+*/
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra 1`] = `
+"cra
+├── index
+│   ├── App
+│   │   ├── App.css
+│   │   └── logo.svg
+│   ├── App.js
+│   ├── App.stories.js
+│   ├── App.test.js
+│   ├── index.css
+│   └── serviceWorker.js
+├── index.js
+└── setupTests.js"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index.js 1`] = `
+"import React from \\"react\\";
+import ReactDOM from \\"react-dom\\";
+import \\"./index/index.css\\";
+import App from \\"./index/App\\";
+import * as serviceWorker from \\"./index/serviceWorker\\";
+
+ReactDOM.render(<App />, document.getElementById(\\"root\\"));
+
+// If you want your app to work offline and load faster, you can change
+// unregister() to register() below. Note this comes with some pitfalls.
+// Learn more about service workers: https://bit.ly/CRA-PWA
+serviceWorker.unregister();
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/App.js 1`] = `
+"import React from \\"react\\";
+import logo from \\"./App/logo.svg\\";
+import \\"./App/App.css\\";
+import \\"./non-existent-file\\";
+
+function App() {
+  return (
+    <div className=\\"App\\">
+      <header className=\\"App-header\\">
+        <img src={logo} className=\\"App-logo\\" alt=\\"logo\\" />
+        <p>
+          Edit <code>src/App.js</code> and save to reload.
+        </p>
+        <a
+          className=\\"App-link\\"
+          href=\\"https://reactjs.org\\"
+          target=\\"_blank\\"
+          rel=\\"noopener noreferrer\\"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default App;
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/App.stories.js 1`] = `
+"import React from \\"react\\";
+import App from \\"./App\\";
+
+export default {
+  title: \\"App\\",
+  component: App,
+};
+
+export function SomeStory() {
+  return <App />;
+}
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/App.test.js 1`] = `
+"import React from \\"react\\";
+import { render } from \\"@testing-library/react\\";
+import App from \\"./App\\";
+
+test(\\"renders learn react link\\", () => {
+  const { getByText } = render(<App />);
+  const linkElement = getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/App/App.css 1`] = `
+".App {
+  text-align: center;
+}
+
+.App-logo {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+@keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/App/logo.svg 1`] = `
+"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 841.9 595.3\\">
+    <g fill=\\"#61DAFB\\">
+        <path d=\\"M666.3 296.5c0-32.5-40.7-63.3-103.1-82.4 14.4-63.6 8-114.2-20.2-130.4-6.5-3.8-14.1-5.6-22.4-5.6v22.3c4.6 0 8.3.9 11.4 2.6 13.6 7.8 19.5 37.5 14.9 75.7-1.1 9.4-2.9 19.3-5.1 29.4-19.6-4.8-41-8.5-63.5-10.9-13.5-18.5-27.5-35.3-41.6-50 32.6-30.3 63.2-46.9 84-46.9V78c-27.5 0-63.5 19.6-99.9 53.6-36.4-33.8-72.4-53.2-99.9-53.2v22.3c20.7 0 51.4 16.5 84 46.6-14 14.7-28 31.4-41.3 49.9-22.6 2.4-44 6.1-63.6 11-2.3-10-4-19.7-5.2-29-4.7-38.2 1.1-67.9 14.6-75.8 3-1.8 6.9-2.6 11.5-2.6V78.5c-8.4 0-16 1.8-22.6 5.6-28.1 16.2-34.4 66.7-19.9 130.1-62.2 19.2-102.7 49.9-102.7 82.3 0 32.5 40.7 63.3 103.1 82.4-14.4 63.6-8 114.2 20.2 130.4 6.5 3.8 14.1 5.6 22.5 5.6 27.5 0 63.5-19.6 99.9-53.6 36.4 33.8 72.4 53.2 99.9 53.2 8.4 0 16-1.8 22.6-5.6 28.1-16.2 34.4-66.7 19.9-130.1 62-19.1 102.5-49.9 102.5-82.3zm-130.2-66.7c-3.7 12.9-8.3 26.2-13.5 39.5-4.1-8-8.4-16-13.1-24-4.6-8-9.5-15.8-14.4-23.4 14.2 2.1 27.9 4.7 41 7.9zm-45.8 106.5c-7.8 13.5-15.8 26.3-24.1 38.2-14.9 1.3-30 2-45.2 2-15.1 0-30.2-.7-45-1.9-8.3-11.9-16.4-24.6-24.2-38-7.6-13.1-14.5-26.4-20.8-39.8 6.2-13.4 13.2-26.8 20.7-39.9 7.8-13.5 15.8-26.3 24.1-38.2 14.9-1.3 30-2 45.2-2 15.1 0 30.2.7 45 1.9 8.3 11.9 16.4 24.6 24.2 38 7.6 13.1 14.5 26.4 20.8 39.8-6.3 13.4-13.2 26.8-20.7 39.9zm32.3-13c5.4 13.4 10 26.8 13.8 39.8-13.1 3.2-26.9 5.9-41.2 8 4.9-7.7 9.8-15.6 14.4-23.7 4.6-8 8.9-16.1 13-24.1zM421.2 430c-9.3-9.6-18.6-20.3-27.8-32 9 .4 18.2.7 27.5.7 9.4 0 18.7-.2 27.8-.7-9 11.7-18.3 22.4-27.5 32zm-74.4-58.9c-14.2-2.1-27.9-4.7-41-7.9 3.7-12.9 8.3-26.2 13.5-39.5 4.1 8 8.4 16 13.1 24 4.7 8 9.5 15.8 14.4 23.4zM420.7 163c9.3 9.6 18.6 20.3 27.8 32-9-.4-18.2-.7-27.5-.7-9.4 0-18.7.2-27.8.7 9-11.7 18.3-22.4 27.5-32zm-74 58.9c-4.9 7.7-9.8 15.6-14.4 23.7-4.6 8-8.9 16-13 24-5.4-13.4-10-26.8-13.8-39.8 13.1-3.1 26.9-5.8 41.2-7.9zm-90.5 125.2c-35.4-15.1-58.3-34.9-58.3-50.6 0-15.7 22.9-35.6 58.3-50.6 8.6-3.7 18-7 27.7-10.1 5.7 19.6 13.2 40 22.5 60.9-9.2 20.8-16.6 41.1-22.2 60.6-9.9-3.1-19.3-6.5-28-10.2zM310 490c-13.6-7.8-19.5-37.5-14.9-75.7 1.1-9.4 2.9-19.3 5.1-29.4 19.6 4.8 41 8.5 63.5 10.9 13.5 18.5 27.5 35.3 41.6 50-32.6 30.3-63.2 46.9-84 46.9-4.5-.1-8.3-1-11.3-2.7zm237.2-76.2c4.7 38.2-1.1 67.9-14.6 75.8-3 1.8-6.9 2.6-11.5 2.6-20.7 0-51.4-16.5-84-46.6 14-14.7 28-31.4 41.3-49.9 22.6-2.4 44-6.1 63.6-11 2.3 10.1 4.1 19.8 5.2 29.1zm38.5-66.7c-8.6 3.7-18 7-27.7 10.1-5.7-19.6-13.2-40-22.5-60.9 9.2-20.8 16.6-41.1 22.2-60.6 9.9 3.1 19.3 6.5 28.1 10.2 35.4 15.1 58.3 34.9 58.3 50.6-.1 15.7-23 35.6-58.4 50.6zM320.8 78.4z\\"/>
+        <circle cx=\\"420.9\\" cy=\\"296.5\\" r=\\"45.7\\"/>
+        <path d=\\"M520.5 78.1z\\"/>
+    </g>
+</svg>
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/index.css 1`] = `
+"body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/index/serviceWorker.js 1`] = `
+"// This optional code is used to register a service worker.
+// register() is not called by default.
+
+// This lets the app load faster on subsequent visits in production, and gives
+// it offline capabilities. However, it also means that developers (and users)
+// will only see deployed updates on subsequent visits to a page, after all the
+// existing tabs open on the page have been closed, since previously cached
+// resources are updated in the background.
+
+// To learn more about the benefits of this model and instructions on how to
+// opt-in, read https://bit.ly/CRA-PWA
+
+const isLocalhost = Boolean(
+  window.location.hostname === \\"localhost\\" ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === \\"[::1]\\" ||
+    // 127.0.0.0/8 are considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\\\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
+
+export function register(config) {
+  if (process.env.NODE_ENV === \\"production\\" && \\"serviceWorker\\" in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+      return;
+    }
+
+    window.addEventListener(\\"load\\", () => {
+      const swUrl = \`\${process.env.PUBLIC_URL}/service-worker.js\`;
+
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, config);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            \\"This web app is being served cache-first by a service \\" +
+              \\"worker. To learn more, visit https://bit.ly/CRA-PWA\\"
+          );
+        });
+      } else {
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, config);
+      }
+    });
+  }
+}
+
+function registerValidSW(swUrl, config) {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then(registration => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        if (installingWorker == null) {
+          return;
+        }
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === \\"installed\\") {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the updated precached content has been fetched,
+              // but the previous service worker will still serve the older
+              // content until all client tabs are closed.
+              console.log(
+                \\"New content is available and will be used when all \\" +
+                  \\"tabs for this page are closed. See https://bit.ly/CRA-PWA.\\"
+              );
+
+              // Execute callback
+              if (config && config.onUpdate) {
+                config.onUpdate(registration);
+              }
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // \\"Content is cached for offline use.\\" message.
+              console.log(\\"Content is cached for offline use.\\");
+
+              // Execute callback
+              if (config && config.onSuccess) {
+                config.onSuccess(registration);
+              }
+            }
+          }
+        };
+      };
+    })
+    .catch(error => {
+      console.error(\\"Error during service worker registration:\\", error);
+    });
+}
+
+function checkValidServiceWorker(swUrl, config) {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl, {
+    headers: { \\"Service-Worker\\": \\"script\\" },
+  })
+    .then(response => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get(\\"content-type\\");
+      if (
+        response.status === 404 ||
+        (contentType != null && contentType.indexOf(\\"javascript\\") === -1)
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then(registration => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl, config);
+      }
+    })
+    .catch(() => {
+      console.log(
+        \\"No internet connection found. App is running in offline mode.\\"
+      );
+    });
+}
+
+export function unregister() {
+  if (\\"serviceWorker\\" in navigator) {
+    navigator.serviceWorker.ready
+      .then(registration => {
+        registration.unregister();
+      })
+      .catch(error => {
+        console.error(error.message);
+      });
+  }
+}
+"
+`;
+
+exports[`end-to-end --avoid-single-file cra: cra/setupTests.js 1`] = `
+"// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import \\"@testing-library/jest-dom/extend-expect\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicate-imports 1`] = `
+"duplicate-imports
+├── index
+│   ├── home.js
+│   └── routes.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file duplicate-imports: duplicate-imports/index.js 1`] = `
+"/* eslint-disable*/
+
+import { five } from \\"./index/routes\\";
+import { five } from \\"./index/routes\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicate-imports: duplicate-imports/index/home.js 1`] = `
+"export const five = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicate-imports: duplicate-imports/index/routes.js 1`] = `
+"export * from \\"./home\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates 1`] = `
+"duplicates
+├── index
+│   ├── dir2-file.js
+│   ├── dir3-sub-file.js
+│   ├── dir4-sub-file.js
+│   ├── dir5
+│   │   ├── dir5-sub2-file.js
+│   │   ├── dir5-sub2-file.spec.js
+│   │   ├── file.js
+│   │   └── file.spec.js
+│   ├── dir5.js
+│   └── file.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index.js 1`] = `
+"require(\\"./index/file\\");
+require(\\"./index/dir2-file\\");
+require(\\"./index/dir3-sub-file\\");
+require(\\"./index/dir4-sub-file\\");
+require(\\"./index/dir5\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir2-file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir3-sub-file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir4-sub-file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir5.js 1`] = `
+"require(\\"./dir5/file\\");
+require(\\"./dir5/dir5-sub2-file\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir5/dir5-sub2-file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir5/dir5-sub2-file.spec.js 1`] = `
+"require(\\"./dir5-sub2-file\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir5/file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/dir5/file.spec.js 1`] = `
+"require(\\"./file\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file duplicates: duplicates/index/file.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file globals 1`] = `
+"src
+├── helper.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file globals: globals/global.js 1`] = `
+"export const bob = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file globals: globals/src/helper.js 1`] = `
+"require(\\"../global\\");
+export const five = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file globals: globals/src/index.js 1`] = `
+"require(\\"./helper\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle 1`] = `
+"index-cycle
+├── index
+│   ├── home.js
+│   ├── login.js
+│   ├── routes.js
+│   └── search.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle: index-cycle/index.js 1`] = `
+"export { five } from \\"./index/routes\\";
+export { seven } from \\"./index/login\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle: index-cycle/index/home.js 1`] = `
+"export const five = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle: index-cycle/index/login.js 1`] = `
+"import { six } from \\"./search\\";
+
+export const seven = six + 1;
+"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle: index-cycle/index/routes.js 1`] = `
+"export * from \\"./home\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file index-cycle: index-cycle/index/search.js 1`] = `
+"import { five } from \\"../index\\";
+
+export const six = five + 1;
+"
+`;
+
+exports[`end-to-end --avoid-single-file sharing 1`] = `
+"sharing
+├── index
+│   ├── footer.js
+│   ├── header.js
+│   └── helper.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file sharing: sharing/index.js 1`] = `
+"export * from \\"./index/footer\\";
+export * from \\"./index/header\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file sharing: sharing/index/footer.js 1`] = `
+"import { five } from \\"./helper\\";
+
+export const seven = five + 2;
+"
+`;
+
+exports[`end-to-end --avoid-single-file sharing: sharing/index/header.js 1`] = `
+"import { five } from \\"./helper\\";
+export const six = five + 1;
+"
+`;
+
+exports[`end-to-end --avoid-single-file sharing: sharing/index/helper.js 1`] = `
+"export const five = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file simple 1`] = `
+"simple
+├── index
+│   ├── home.js
+│   └── routes.js
+└── index.js"
+`;
+
+exports[`end-to-end --avoid-single-file simple: simple/index.js 1`] = `
+"import { five } from \\"./index/routes\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file simple: simple/index/home.js 1`] = `
+"export const five = 5;
+"
+`;
+
+exports[`end-to-end --avoid-single-file simple: simple/index/routes.js 1`] = `
+"export * from \\"./home\\";
+"
+`;
+
+exports[`end-to-end --avoid-single-file single-file-folder 1`] = `
+"single-file-folder
+├── file.js
+└── page.js"
+`;
+
+exports[`end-to-end --avoid-single-file single-file-folder: single-file-folder/file.js 1`] = `
+"const page = require('./page');
+
+export const file =  {
+  name: 'file.ts',
+  page
+};
+"
+`;
+
+exports[`end-to-end --avoid-single-file single-file-folder: single-file-folder/page.js 1`] = `
+"export const page = {
+  name: 'page.ts'
+};
+"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files 1`] = `
+"spec-files
+├── index
+│   ├── level1
+│   │   ├── level2.js
+│   │   └── level2.spec.js
+│   ├── level1.js
+│   └── level1.spec.js
+├── index.js
+└── index.spec.js"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index.js 1`] = `
+"require(\\"./index/level1\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index.spec.js 1`] = `
+"require(\\"./index\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index/level1.js 1`] = `
+"require(\\"./level1/level2\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index/level1.spec.js 1`] = `
+"require(\\"./level1\\");
+"
+`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index/level1/level2.js 1`] = `""`;
+
+exports[`end-to-end --avoid-single-file spec-files: spec-files/index/level1/level2.spec.js 1`] = `
+"require(\\"./level2\\");
+"
+`;
+
 exports[`end-to-end commented-imports 1`] = `
 "commented-imports
 ├── index
@@ -537,6 +1132,30 @@ exports[`end-to-end simple: simple/index/routes.js 1`] = `
 
 exports[`end-to-end simple: simple/index/routes/home.js 1`] = `
 "export const five = 5;
+"
+`;
+
+exports[`end-to-end single-file-folder 1`] = `
+"single-file-folder
+├── file
+│   └── page.js
+└── file.js"
+`;
+
+exports[`end-to-end single-file-folder: single-file-folder/file.js 1`] = `
+"const page = require('./file/page');
+
+export const file =  {
+  name: 'file.ts',
+  page
+};
+"
+`;
+
+exports[`end-to-end single-file-folder: single-file-folder/file/page.js 1`] = `
+"export const page = {
+  name: 'page.ts'
+};
 "
 `;
 

--- a/tests/build-graph.test.ts
+++ b/tests/build-graph.test.ts
@@ -50,4 +50,8 @@ describe("build graph", () => {
   t("commented-imports", {
     "index.js": ["existent.js"],
   });
+
+  t("single-file-folder", {
+    "file.js": ["page/page.js"]
+  });
 });

--- a/tests/end-to-end.test.ts
+++ b/tests/end-to-end.test.ts
@@ -61,3 +61,28 @@ describe("end-to-end", () => {
     });
   }
 });
+
+describe("end-to-end --avoid-single-file", () => {
+  const fixturePath = path.join(__dirname, "fixtures");
+  const testCases = fs.readdirSync(fixturePath);
+
+  for (const testCase of testCases) {
+    const templateFolder = path.join(fixturePath, testCase);
+    const copyPath = path.join(tmpPath, testCase);
+
+    fs.copySync(templateFolder, copyPath);
+    it(testCase, async () => {
+      const rootPath =
+        testCase === "globals" ? path.join(testCase, "src") : testCase;
+
+      await run(["--write", "--avoid-single-file", path.join(tmpPath, rootPath)]);
+      buildGraph(glob.sync(path.join(copyPath, "/**/*.*")));
+      expect(treeDir(path.join(tmpPath, rootPath))).toMatchSnapshot();
+
+      const treeContents = treeDirWithContents(copyPath);
+      Object.keys(treeContents).forEach(k => {
+        expect(treeContents[k]).toMatchSnapshot(k);
+      });
+    });
+  }
+})

--- a/tests/fixtures/single-file-folder/file.js
+++ b/tests/fixtures/single-file-folder/file.js
@@ -1,0 +1,6 @@
+const page = require('./page/page');
+
+export const file =  {
+  name: 'file.ts',
+  page
+};

--- a/tests/fixtures/single-file-folder/page/page.js
+++ b/tests/fixtures/single-file-folder/page/page.js
@@ -1,0 +1,3 @@
+export const page = {
+  name: 'page.ts'
+};


### PR DESCRIPTION
This PR adds a flag/option to avoid folders with single files.

Changes:

- Some small refactor/renaming in `buildGraph` and `toFractalTree` to increase the readability. This was done while exploring the code to implement this issue.
- Add postprocessor to analyze the fractal tree and rewrite the tree when the `--rename-only-child` flag is enabled.
- Update tests and added a new folder fixture.
- Fixed unreliable testing due misconfiguration in `jest.config.js`

I need some help to rename the function `detect-lonely-files` to something more appropriate.