### PR TITLE
Tests for logger

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 
 export const error = (err: Error | string, code = 0) => {
   if (process.env.NODE_ENV === "test") return;
-  const text = err instanceof Error ? err : chalk.red.bold(`ERROR: ${err}`);
+  const text = err instanceof Error ? err : chalk.red.bold("ERROR: ") + err;
   console.error(text);
   console.log(
     "If you think this is a bug, you can report it: https://github.com/benawad/destiny/issues"
@@ -12,7 +12,7 @@ export const error = (err: Error | string, code = 0) => {
 
 export const info = (msg: string) => {
   if (process.env.NODE_ENV === "test") return;
-  const text = chalk.green.bold(`INFO: ${msg}`);
+  const text = chalk.green.bold("INFO: ") + msg;
   console.info(text);
 };
 
@@ -23,7 +23,7 @@ export const log = (msg: string) => {
 
 export const warn = (msg: string) => {
   if (process.env.NODE_ENV === "test") return;
-  const text = chalk.yellow.bold(`WARN: ${msg}`);
+  const text = chalk.yellow.bold("WARN: ") + msg;
   console.warn(text);
 };
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -2,21 +2,18 @@ import chalk from "chalk";
 
 export const error = (err: Error | string, code = 0) => {
   if (process.env.NODE_ENV === "test") return;
-  if (err instanceof Error) {
-    console.error(err);
-  } else {
-    console.error(chalk`{red.bold ERROR:} ${err}`);
-  }
+  const text = err instanceof Error ? err : chalk.red.bold(`ERROR: ${err}`);
+  console.error(text);
   console.log(
     "If you think this is a bug, you can report it: https://github.com/benawad/destiny/issues"
   );
-
   process.exit(code);
 };
 
 export const info = (msg: string) => {
   if (process.env.NODE_ENV === "test") return;
-  console.info(chalk`{green.bold INFO:} ${msg}`);
+  const text = chalk.green.bold(`INFO: ${msg}`);
+  console.info(text);
 };
 
 export const log = (msg: string) => {
@@ -26,7 +23,8 @@ export const log = (msg: string) => {
 
 export const warn = (msg: string) => {
   if (process.env.NODE_ENV === "test") return;
-  console.warn(chalk`{yellow.bold WARN:} ${msg}`);
+  const text = chalk.yellow.bold(`WARN: ${msg}`);
+  console.warn(text);
 };
 
 export default { error, info, log, warn };

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,81 @@
+import chalk from "chalk";
+import logger from "../src/shared/logger";
+
+const mocks = {
+  error: jest.spyOn(console, "error").mockImplementationOnce(() => {}),
+  log: jest.spyOn(console, "log").mockImplementationOnce(() => {}),
+  info: jest.spyOn(console, "info").mockImplementationOnce(() => {}),
+  warn: jest.spyOn(console, "warn").mockImplementationOnce(() => {}),
+  exit: jest
+    .spyOn(process, "exit")
+    // @ts-ignore - eslint won't allow assertion of `code as never`
+    .mockImplementationOnce(code => code),
+};
+
+afterEach(() => {
+  jest.resetAllMocks();
+  jest.resetModules();
+});
+
+describe('NODE_ENV === "test"', () => {
+  describe.each(Object.keys(logger))("logger.%s", name => {
+    test(`stops execution of logger.${name} if in a test environment`, () => {
+      logger[name]("a test message");
+      expect(mocks.error).toBeCalledTimes(0);
+      expect(mocks.info).toBeCalledTimes(0);
+      expect(mocks.log).toBeCalledTimes(0);
+      expect(mocks.warn).toBeCalledTimes(0);
+      expect(mocks.exit).toBeCalledTimes(0);
+    });
+  });
+});
+
+describe('NODE_ENV === "production"', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "production";
+  });
+
+  const message = "a test message!";
+  const table = [
+    ["info", chalk.green.bold(`INFO: ${message}`)],
+    ["warn", chalk.yellow.bold(`WARN: ${message}`)],
+    ["log", message],
+  ];
+
+  describe.each(table)("logger.%s", (name, msg) => {
+    test(`calls "console.${name}()" with "${msg}"`, () => {
+      logger[name](message);
+      const mock = mocks[name];
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith(msg);
+    });
+  });
+
+  describe(`logger.error`, () => {
+    it('calls "console.error()" when passed an error instances', () => {
+      const error = new Error();
+      logger.error(error);
+
+      expect(mocks.error).toBeCalledTimes(1);
+      expect(mocks.error).toBeCalledWith(error);
+      expect(mocks.log).toBeCalledTimes(1);
+      expect(mocks.exit).toBeCalledTimes(1);
+    });
+
+    it('calls "console.error()" with chalk when passed a string', () => {
+      const msg = "A test message";
+      const result = chalk.red.bold(`ERROR: ${msg}`);
+      logger.error(msg);
+      expect(mocks.error).toBeCalledTimes(1);
+      expect(mocks.error).toBeCalledWith(result);
+      expect(mocks.exit).toBeCalledTimes(1);
+    });
+
+    it('exits process with error code "1"', () => {
+      logger.error("", 1);
+      expect(mocks.error).toBeCalledTimes(1);
+      expect(mocks.exit).toBeCalledTimes(1);
+      expect(mocks.exit).toBeCalledWith(1);
+    });
+  });
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -37,8 +37,8 @@ describe('NODE_ENV === "production"', () => {
 
   const message = "a test message!";
   const table = [
-    ["info", chalk.green.bold(`INFO: ${message}`)],
-    ["warn", chalk.yellow.bold(`WARN: ${message}`)],
+    ["info", chalk.green.bold("INFO: ") + message],
+    ["warn", chalk.yellow.bold("WARN: ") + message],
     ["log", message],
   ];
 
@@ -64,7 +64,7 @@ describe('NODE_ENV === "production"', () => {
 
     it('calls "console.error()" with chalk when passed a string', () => {
       const msg = "A test message";
-      const result = chalk.red.bold(`ERROR: ${msg}`);
+      const result = chalk.red.bold("ERROR: ") + msg;
       logger.error(msg);
       expect(mocks.error).toBeCalledTimes(1);
       expect(mocks.error).toBeCalledWith(result);

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -21,11 +21,9 @@ describe('NODE_ENV === "test"', () => {
   describe.each(Object.keys(logger))("logger.%s", name => {
     test(`stops execution of logger.${name} if in a test environment`, () => {
       logger[name]("a test message");
-      expect(mocks.error).toBeCalledTimes(0);
-      expect(mocks.info).toBeCalledTimes(0);
-      expect(mocks.log).toBeCalledTimes(0);
-      expect(mocks.warn).toBeCalledTimes(0);
-      expect(mocks.exit).toBeCalledTimes(0);
+      for (const mock of Object.values(mocks)) {
+        expect(mock).not.toBeCalled();
+      }
     });
   });
 });
@@ -53,7 +51,7 @@ describe('NODE_ENV === "production"', () => {
 
   describe(`logger.error`, () => {
     it('calls "console.error()" when passed an error instances', () => {
-      const error = new Error();
+      const error = new Error("test error");
       logger.error(error);
 
       expect(mocks.error).toBeCalledTimes(1);
@@ -72,10 +70,11 @@ describe('NODE_ENV === "production"', () => {
     });
 
     it('exits process with error code "1"', () => {
-      logger.error("", 1);
+      const exitCode = 1;
+      logger.error("", exitCode);
       expect(mocks.error).toBeCalledTimes(1);
       expect(mocks.exit).toBeCalledTimes(1);
-      expect(mocks.exit).toBeCalledWith(1);
+      expect(mocks.exit).toBeCalledWith(exitCode);
     });
   });
 });


### PR DESCRIPTION
#80 Tests for the logger.

I've used `jest.resetModules()` alongside `beforeEach()` and `afterEach()` to change `process.env.NODE_ENV` from `"test"` to `"production"`, as `logger[name]` relies on `NODE_ENV` not to be in test mode.

Test coverage is 100% for this module.

~~Can I have someone check out these tests? I've never written tests like this before and am unsure what the standard.~~

~~I made the helper functions because I'll use them for the other log functions.~~

~~I extended this branch off a previous pull, which is why there is all this other stuff. I'll get rid of it later before opening up.~~