### PR TITLE
Adds .d.ts extension to customResolve

### DIFF
--- a/src/index/shared/customResolve.ts
+++ b/src/index/shared/customResolve.ts
@@ -8,6 +8,7 @@ const extensions = [
   ".scss",
   ".svg",
   ".ts",
+  ".d.ts",
   ".tsx",
   ".js.flow",
 ];


### PR DESCRIPTION
:wave: Cool tool!

The `.d.ts` extension is used for TypeScript Definition Files. My project has a few instances where they're imported directly. Destiny was throwing an error that it `Cannot find import`, but after adding this extension locally it worked fine.