### PR TITLE
Fixing imports in string

### DIFF
--- a/src/index/shared/findImports.ts
+++ b/src/index/shared/findImports.ts
@@ -2,12 +2,22 @@ import fs from "fs";
 
 /** Find all imports for file path. */
 export function findImports(filePath: string) {
-  const reImport = /(?:(?:import|from)\s+|(?:import|require)\s*\()['"]((?:\.{1,2})(?:\/.+)?)['"]/gm;
+  // match es5 & es6 imports
+  const _reImport = `(?:(?:import|from)\\s+|(?:import|require)\\s*\\()['"]((?:\\.{1,2})(?:\\/.+)?)['"]`;
+  const reImport = new RegExp(_reImport, "gm");
+  // match one & multi line(s) comments
   const reComment = /\/\*[\s\S]*?\*\/|\/\/.*/gm;
+  // match string which contain an import https://github.com/benawad/destiny/issues/111
+  const reOneLineString = new RegExp(`["'].*(${_reImport}).*["']`, "g");
+  // match multi lines string which contain an import https://github.com/benawad/destiny/issues/111
+  const reMultiLinesString = new RegExp(`\`[^]*(${_reImport})[^]*\``, "gm");
+
   const importPaths: string[] = [];
   const fileContent = fs
     .readFileSync(filePath, { encoding: "utf8" })
-    .replace(reComment, "");
+    .replace(reComment, "")
+    .replace(reOneLineString, "")
+    .replace(reMultiLinesString, "");
 
   let matches;
   while ((matches = reImport.exec(fileContent)) !== null) {

--- a/tests/findImports.test.ts
+++ b/tests/findImports.test.ts
@@ -46,4 +46,6 @@ describe("findImports", () => {
     "commented-line",
     ["./module"]
   );
+
+  t("doesn't match with imports in string", "import-in-string", ["./module"]);
 });

--- a/tests/imports/import-in-string/index.js
+++ b/tests/imports/import-in-string/index.js
@@ -1,0 +1,66 @@
+import module from "./module";
+
+// prettier-ignore
+module("import test from \"./test1\"");
+// prettier-ignore
+module('import test from "./test2"');
+// prettier-ignore
+module(`import test from "./test3"`);
+
+// prettier-ignore
+module('import test from \'./test4\'');
+// prettier-ignore
+module("import test from './test5'");
+// prettier-ignore
+module(`import test from './test6'`);
+
+// prettier-ignore
+module(`import test from \`./test7\``);
+// prettier-ignore
+module("import test from `./test8`");
+// prettier-ignore
+module('import test from `./test9`');
+
+// prettier-ingore
+module(`
+  this is just
+
+  import test "./test10"
+  a random multi lines string
+
+  which contain an es6 import
+`);
+
+// prettier-ignore
+module("const test = require(\"./test11\")");
+// prettier-ignore
+module('const test = require("./test12")');
+// prettier-ignore
+module(`const test = require("./test13")`);
+
+// prettier-ignore
+module('const test = require(\'./test14\')');
+// prettier-ignore
+module("const test = require('./test15')");
+// prettier-ignore
+module(`const test = require('./test16')`);
+
+// prettier-ignore
+module(`const test = require(\`./test17\`)`);
+
+// prettier-ignore
+module(`const test = require(\`./test18\`)`);
+// prettier-ignore
+module("const test = require(./test19`)");
+// prettier-ignore
+module('const test = require(./test20`)');
+
+// prettier-ingore
+module(`
+  this is just
+
+  const test = require("./test21")
+  a random multi lines string
+
+  which contain an es5 import
+`);

--- a/tests/imports/import-in-string/module.js
+++ b/tests/imports/import-in-string/module.js
@@ -1,0 +1,1 @@
+export default () => null;


### PR DESCRIPTION
Fix #111.

With this pr, `findImports` basically remove string(s) which contain an import.
E.g.:
```js
const a = "import module from './module'"
````
This code was recognized as an import by Destiny, this pr fix it.