### PR TITLE
fix: #128

### DIFF
--- a/src/index/generateTrees/buildGraph.ts
+++ b/src/index/generateTrees/buildGraph.ts
@@ -26,14 +26,14 @@ export function buildGraph(filePaths: string[]) {
     const start = path.relative(parentFolder, filePath);
     totalFiles.push(start);
 
-    findImports(filePath).forEach(importPath => {
+    findImports(filePath).forEach(_import => {
       const pathWithExtension = customResolve(
-        importPath,
+        _import.path,
         path.dirname(filePath)
       );
 
       if (pathWithExtension == null) {
-        logger.error(`Cannot find import ${importPath} for ${filePath}`);
+        logger.error(`Cannot find import ${_import.path} for ${filePath}`);
         return;
       }
 

--- a/src/index/shared/findImports.ts
+++ b/src/index/shared/findImports.ts
@@ -3,29 +3,34 @@ import fs from "fs";
 /** Find all imports for file path. */
 export function findImports(filePath: string) {
   // match es5 & es6 imports
-  const _reImport = `(?:(?:import|from)\\s+|(?:import|require)\\s*\\()['"]((?:\\.{1,2})(?:\\/.+)?)['"]`;
+  const _reImport = `(?:(?:import|from)\\s+|(?:import|require)\\s*\\()\\\\?['"\`]((?:\\.{1,2})(?:\\/.+)?)\\\\?['"\`]`;
   const reImport = new RegExp(_reImport, "gm");
   // match one & multi line(s) comments
   const reComment = /\/\*[\s\S]*?\*\/|\/\/.*/gm;
   // match string which contain an import https://github.com/benawad/destiny/issues/111
-  const reOneLineString = new RegExp(`["'].*(${_reImport}).*["']`, "g");
+  const reOneLineString = new RegExp(`["'\`].*(${_reImport}).*["'\`]`, "g");
   // match multi lines string which contain an import https://github.com/benawad/destiny/issues/111
-  const reMultiLinesString = new RegExp(`\`[^]*(${_reImport})[^]*\``, "gm");
+  const reMultiLinesString = new RegExp(`\`[^\`]*(${_reImport})[^\`]*\``, "gm");
 
-  const importPaths: string[] = [];
+  const replaceBySpaces = (match: string) => " ".repeat(match.length);
+
+  const importPaths: { path: string; start: number; end: number }[] = [];
   const fileContent = fs
     .readFileSync(filePath, { encoding: "utf8" })
-    .replace(reComment, "")
-    .replace(reOneLineString, "")
-    .replace(reMultiLinesString, "");
+    .replace(reComment, replaceBySpaces)
+    .replace(reOneLineString, replaceBySpaces)
+    .replace(reMultiLinesString, replaceBySpaces);
 
   let matches;
   while ((matches = reImport.exec(fileContent)) !== null) {
+    importPaths.push({
+      path: matches[1],
+      start: reImport.lastIndex - 1 - matches[1].length,
+      end: reImport.lastIndex - 1,
+    });
+
     // This is necessary to avoid infinite loops with zero-width matches.
-    if (matches.index === reImport.lastIndex) {
-      reImport.lastIndex++;
-    }
-    importPaths.push(matches[1]);
+    if (matches.index === reImport.lastIndex) reImport.lastIndex++;
   }
 
   return importPaths;

--- a/tests/findImports.test.ts
+++ b/tests/findImports.test.ts
@@ -2,7 +2,11 @@ import path from "path";
 import fs from "fs";
 import { findImports } from "../src/index/shared/findImports";
 
-const t = (name: string, fixtureName: string, result: string[]) => {
+const t = (
+  name: string,
+  fixtureName: string,
+  result: ReturnType<typeof findImports>
+) => {
   it(name, () => {
     const fixturePath = path.resolve(
       __dirname,
@@ -21,31 +25,46 @@ const t = (name: string, fixtureName: string, result: string[]) => {
 };
 
 describe("findImports", () => {
-  t("resolve es6 default import", "es6-default", ["./module"]);
+  t("resolve es6 default import", "es6-default", [
+    { path: "./module", start: 25, end: 33 },
+  ]);
 
-  t("resolve es6 export from module", "es6-export-module", ["./module"]);
+  t("resolve es6 export from module", "es6-export-module", [
+    { path: "./module", start: 15, end: 23 },
+  ]);
 
-  t("resolve es6 alias default import", "es6-alias-default", ["./module"]);
+  t("resolve es6 alias default import", "es6-alias-default", [
+    { path: "./module", start: 25, end: 33 },
+  ]);
 
-  t("resolve es6 named import", "es6-named", ["./module"]);
+  t("resolve es6 named import", "es6-named", [
+    { path: "./module", start: 29, end: 37 },
+  ]);
 
-  t("resolve es5 require", "es5-require", ["./module"]);
+  t("resolve es5 require", "es5-require", [
+    { path: "./module", start: 9, end: 17 },
+  ]);
 
   t("resolve es5 require stored in variable", "es5-variable-require", [
-    "./module",
+    { path: "./module", start: 29, end: 37 },
   ]);
 
   t(
     "resolve es5 multiple require stored in chained variables",
     "es5-chained-variable-require",
-    ["./module1", "./module2"]
+    [
+      { path: "./module1", start: 61, end: 70 },
+      { path: "./module2", start: 95, end: 104 },
+    ]
   );
 
   t(
     "doesn't ignore imports with a comment on the same line",
     "commented-line",
-    ["./module"]
+    [{ path: "./module", start: 20, end: 28 }]
   );
 
-  t("doesn't match with imports in string", "import-in-string", ["./module"]);
+  t("doesn't match with imports in string", "import-in-string", [
+    { path: "./module", start: 20, end: 28 },
+  ]);
 });


### PR DESCRIPTION
fix: #128

Also some improvements on the regex:
- add match for import using backticks string ``import a from `./a`;``
- "one line string" regex also match with backticks ``const a = `one line string`;``
- fixing when a "multi lines string" match didn't stopped where it should
- add match for escaped quotes in import, that's useful to detect when a string has an import written inside it (#111). `const i = "import a from \"./a\""`