### PR TITLE
fix: #135

### DIFF
--- a/src/index/formatFileStructure/fixImports.ts
+++ b/src/index/formatFileStructure/fixImports.ts
@@ -22,20 +22,18 @@ const getNewImportPath = (
   newFilePath: string,
   rootOptions: RootOption[]
 ) => {
-  let lastUseForwardSlash = true;
-  for (const { tree, parentFolder, useForwardSlash } of rootOptions) {
-    lastUseForwardSlash = useForwardSlash;
+  for (const { tree, parentFolder } of rootOptions) {
     const key = path.relative(parentFolder, absImportPath);
+
     if (key in tree) {
       return makeImportPath(
         newFilePath,
-        path.resolve(path.join(parentFolder, tree[key])),
-        useForwardSlash
+        path.resolve(path.join(parentFolder, tree[key]))
       );
     }
   }
 
-  return makeImportPath(newFilePath, absImportPath, lastUseForwardSlash);
+  return makeImportPath(newFilePath, absImportPath);
 };
 
 export const fixImports = (filePaths: string[], rootOptions: RootOption[]) => {

--- a/src/index/formatFileStructure/fixImports/makeImportPath.ts
+++ b/src/index/formatFileStructure/fixImports/makeImportPath.ts
@@ -6,11 +6,7 @@ function getExtensionFromImport(relativePath: string) {
   return includeExtension ? ext : undefined;
 }
 
-export const makeImportPath = (
-  fromPath: string,
-  toPath: string,
-  useForwardSlashes: boolean
-) => {
+export const makeImportPath = (fromPath: string, toPath: string) => {
   const fromDirectory = path.dirname(fromPath);
   const relativePath = path.relative(fromDirectory, toPath);
 
@@ -33,12 +29,8 @@ export const makeImportPath = (
     newImport = "./" + newImport;
   }
 
-  // Replace / and \ with \\.
-  if (!useForwardSlashes) {
-    newImport = newImport.replace(/\/|\\+/g, "\\\\");
-  }
-  // Replace \ with /.
-  else {
+  // Replace \\ by /.
+  if (process.platform === "win32") {
     newImport = newImport.replace(/\\/g, "/");
   }
 

--- a/src/index/generateTrees.ts
+++ b/src/index/generateTrees.ts
@@ -22,9 +22,7 @@ export function generateTrees(
 
       logger.info(`Generating tree for: ${rootPath}`);
 
-      const { graph, files, useForwardSlash, parentFolder } = buildGraph(
-        filePaths
-      );
+      const { graph, files, parentFolder } = buildGraph(filePaths);
 
       let tree = toFractalTree(graph, findEntryPoints(graph));
 
@@ -50,7 +48,6 @@ export function generateTrees(
       rootOptions.push({
         parentFolder,
         tree,
-        useForwardSlash,
       });
 
       return rootOptions;

--- a/src/index/generateTrees/buildGraph.ts
+++ b/src/index/generateTrees/buildGraph.ts
@@ -52,6 +52,5 @@ export function buildGraph(filePaths: string[]) {
     files: totalFiles,
     graph,
     parentFolder,
-    useForwardSlash: path.sep === "/",
   };
 }

--- a/src/index/getFilePaths.ts
+++ b/src/index/getFilePaths.ts
@@ -7,7 +7,11 @@ const isDirectory = (filePath: string) => fs.lstatSync(filePath).isDirectory();
 const isFile = (filePath: string) => fs.lstatSync(filePath).isFile();
 
 export const globSearch = (pattern: string) => {
-  const matches = glob.sync(pattern);
+  const matches = glob
+    .sync(pattern)
+    // convert forward slashes to backslashes on windows
+    .map(filePath => path.resolve(filePath));
+
   const files = matches.filter(match => isFile(match));
 
   logger.debug(`glob matches for "${pattern}":`, matches);

--- a/src/index/shared/RootOption.ts
+++ b/src/index/shared/RootOption.ts
@@ -1,5 +1,4 @@
 export type RootOption = {
   parentFolder: string;
   tree: Record<string, string>;
-  useForwardSlash: boolean;
 };


### PR DESCRIPTION
According to this issue: https://github.com/nodejs/node/issues/31710, Node doesn't support backslash in an import. So I've just dropped the backslash when writing imports, but paths are still logged with backslash on windows (as they should).

![](https://i.gyazo.com/d38320492205f4477473062da361f055.png)