### PR TITLE
fix debugging jest tests in windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,19 @@
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Tests in Windows",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,26 +5,9 @@
       "name": "Debug Jest Tests",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--runInBand",
-        "end-to-end",
-        "-t",
-        "shared-with-dependencies"
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug Jest Tests in Windows",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["--runInBand"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }


### PR DESCRIPTION
Fixes https://github.com/benawad/destiny/issues/157#issuecomment-718917205 (only the part where I wasn't able to attach a debugger, resulting in a weird error). 

After some research, I found [this](https://medium.com/guidesmiths-dev/how-to-configure-visual-studio-code-for-test-debugging-39d0d7f24d79) article with a ```launch.json``` configuration that wasn't failing when debugging Jest tests in windows.

Right now I can't test it in other OS, but let me know if the new configuration works for macOS since then we can safely remove the first one.
